### PR TITLE
remove netdata_nightly property

### DIFF
--- a/__tests__/index.js
+++ b/__tests__/index.js
@@ -25,42 +25,6 @@ test('setupPlugin', async () => {
     expect(getMeta().global.setupDone).toEqual(true)
 })
 
-// test netdata_nightly logic
-test('netdata_nightly', async () => {
-
-    // create a eventNetdataNotNightly test event
-    const eventNetdataNotNightly = createEvent({ event: 'test event', properties: { netdata_version: 'v1.29.2' } })
-    const eventNetdataNotNightlyCopy = await processEvent(clone(eventNetdataNotNightly), getMeta())
-    expect(eventNetdataNotNightlyCopy).toEqual({
-        ...eventNetdataNotNightly,
-        properties: {
-            ...eventNetdataNotNightly.properties,
-            netdata_nightly: false,
-            netdata_posthog_plugin_version: netdataPluginVersion,
-            interaction_type: 'other',
-            interaction_detail: '',
-            interaction_token: 'other|',
-            event_ph: 'test event'
-        },
-    })
-
-    // create a eventNetdataNightly test event
-    const eventNetdataNightly = createEvent({ event: 'test event', properties: { netdata_version: 'v1.29.2-25-nightly' } })
-    const eventNetdataNightlyCopy = await processEvent(clone(eventNetdataNightly), getMeta())
-    expect(eventNetdataNightlyCopy).toEqual({
-        ...eventNetdataNightly,
-        properties: {
-            ...eventNetdataNightly.properties,
-            netdata_nightly: true,
-            netdata_posthog_plugin_version: netdataPluginVersion,
-            interaction_type: 'other',
-            interaction_detail: '',
-            interaction_token: 'other|',
-            event_ph: 'test event'
-        },
-    })
-})
-
 // test has_alarms_critical
 test('has_alarms_critical', async () => {
     const event = createEvent({ event: 'test event', properties: { "alarms_critical": 1 } })

--- a/index.js
+++ b/index.js
@@ -651,11 +651,6 @@ function processElements(event) {
 }
 
 function processProperties(event) {
-    // check if netdata_version property exists
-    if (event.properties['netdata_version']) {
-        // flag if a nightly version
-        event.properties['netdata_nightly'] = !!event.properties['netdata_version'].includes('nightly');
-    }
 
     // has_alarms_critical
     if (typeof event.properties['alarms_critical'] === 'number') {

--- a/process_properties.js
+++ b/process_properties.js
@@ -3,11 +3,6 @@ import {getInteractionType} from "./interaction_type";
 import {getInteractionDetail} from "./interaction_detail";
 
 export function processProperties(event) {
-    // check if netdata_version property exists
-    if (event.properties['netdata_version']) {
-        // flag if a nightly version
-        event.properties['netdata_nightly'] = !!event.properties['netdata_version'].includes('nightly');
-    }
 
     // has_alarms_critical
     if (typeof event.properties['alarms_critical'] === 'number') {


### PR DESCRIPTION
this will be replaced by `netdata_release_channel` which is now being calculated by the anon stats code itself and so we don't need this hacky approach of using the netdata_version string anymore. 